### PR TITLE
Check log-buffer for liveness as well

### DIFF
--- a/emacsql.el
+++ b/emacsql.el
@@ -106,7 +106,9 @@ If nil, wait forever.")
 
 (cl-defmethod emacsql-live-p ((connection emacsql-connection))
   "Return non-nil if CONNECTION is still alive and ready."
-  (not (null (process-live-p (emacsql-process connection)))))
+  (and (not (null (process-live-p (emacsql-process connection))))
+       (or (null (emacsql-log-buffer connection))
+           (buffer-live-p (emacsql-log-buffer connection)))))
 
 (cl-defgeneric emacsql-types (connection)
   "Return an alist mapping EmacSQL types to database types.


### PR DESCRIPTION
This was causing an error when using magit-forge because `emacsql-live-p` returned `t`, but then when calling `emacsql-log` it doesn't check live-ness, only that it's non-nil, before using it in `with-current-buffer`.  Anyway, I'm not sure this is the best way to fix the problem, but (with my lack of understanding of how the code is supposed to work), it seemed better than changing `emacsql-log` since it would at least give the client an opportunity to fix the problem rather than silently turning off logging.

For me, this fixes #60.