### PR TITLE
Check mysql executable before invoke command

### DIFF
--- a/emacsql-mysql.el
+++ b/emacsql-mysql.el
@@ -72,6 +72,8 @@ http://dev.mysql.com/doc/refman/5.5/en/reserved-words.html")
   "Connect to a MySQL server using the mysql command line program."
   (let* ((mysql (executable-find emacsql-mysql-executable))
          (command (list database "--skip-pager" "-rfBNL" mysql)))
+    (unless mysql
+      (user-error "Cannot find `mysql' executable.  Please check instalation or PATH configuration"))
     (when user     (push (format "--user=%s" user) command))
     (when password (push (format "--password=%s" password) command))
     (when host     (push (format "--host=%s" host) command))


### PR DESCRIPTION
Hi!
I find this package and try it, I face error.
Finally, there're some PATH issue, so my Emacs could not find `mysql` executable.

My change is to display warnings before invoke command if the package can't find mysql.