### PR TITLE
Fix describe-function initialize-instance

### DIFF
--- a/emacsql-sqlite.el
+++ b/emacsql-sqlite.el
@@ -82,7 +82,7 @@ used.")
   (:documentation "A connection to a SQLite database."))
 
 (cl-defmethod initialize-instance :after
-  ((connection emacsql-sqlite-connection) &rest _)
+  ((connection emacsql-sqlite-connection) &rest _rest)
   (emacsql-sqlite-ensure-binary)
   (let* ((process-connection-type nil)  ; use a pipe
          (coding-system-for-write 'utf-8-auto)


### PR DESCRIPTION
There is an issue with the arglist of method 
`initialize-instance :after ((connection emacsql-sqlite-connection) &rest _)`
  
`_` is at some point stripped from the symbol name of the `&rest` argument which causes a zero-length symbol to be read from string `docargs` in `help-function-arglist` which name is then subjected to `(aref name 0)` which errors e.g. any time `(describe-function #'initialize-instance)` is called.

Reproducible with

```
emacs -Q -L /usr/share/emacs/site-lisp/emacsql/
```
(or whatever your path is)

then
```
(require 'emacsql-sqlite)
```

and `C-h f initialize-instance`

Notes:

- It might be worth it to fix the issue at the Emacs level.  I'm not ready to do it right now.
- Maybe the issue is fixed in Emacs 28; I did not check.