### PR TITLE
Add two new sqlite backends, using builtin support and a module [also talk about maintainership transfer]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ BATCH   = $(EMACS) -batch -Q -L . -L tests $(LDFLAGS)
 EL = emacsql-compiler.el \
      emacsql.el \
      emacsql-sqlite.el \
+     emacsql-sqlite-builtin.el \
      emacsql-sqlite-module.el \
      emacsql-psql.el \
      emacsql-mysql.el \

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,20 @@
 # Clone the dependencies of this package in sibling directories:
 #     $ git clone https://github.com/cbbrowne/pg.el ../pg
+#     $ git clone https://github.com/pekingduck/emacs-sqlite3-api.git ../sqlite3
 #
 # Or set LDFLAGS to point at these packages elsewhere:
-#     $ make LDFLAGS='-L path/to/pg'
+#     $ make LDFLAGS='-L path/to/pg -L path/to/sqlite3'
 
 .POSIX:
 .SUFFIXES: .el .elc
 EMACS   = emacs
-LDFLAGS = -L ../pg
+LDFLAGS = -L ../pg -L ../sqlite3
 BATCH   = $(EMACS) -batch -Q -L . -L tests $(LDFLAGS)
 
 EL = emacsql-compiler.el \
      emacsql.el \
      emacsql-sqlite.el \
+     emacsql-sqlite-module.el \
      emacsql-psql.el \
      emacsql-mysql.el \
      emacsql-pg.el

--- a/emacsql-sqlite-builtin.el
+++ b/emacsql-sqlite-builtin.el
@@ -1,0 +1,90 @@
+;;; emacsql-sqlite-builtin.el --- EmacSQL back-end for SQLite using builtin support  -*- lexical-binding: t; -*-
+
+;; This is free and unencumbered software released into the public domain.
+
+;; Author: Christopher Wellons <wellons@nullprogram.com>
+;; URL: https://github.com/skeeto/emacsql
+;; Version: 3.0.0-git
+;; Package-Requires: ((emacs "29") (emacsql "3.0.0") (emacsql-sqlite "3.0.0"))
+
+;;; Commentary:
+
+;; EmacSQL back-end for SQLite using builtin support added in Emacs 29.
+
+;;; Code:
+
+(require 'sqlite)
+(require 'emacsql)
+;; For `emacsql-sqlite-reserved' and `emacsql-sqlite-condition-alist'.
+(require 'emacsql-sqlite)
+
+(defclass emacsql-sqlite-builtin-connection (emacsql-connection)
+  ((file :initarg :file
+         :type (or null string)
+         :documentation "Database file name.")
+   (types :allocation :class
+          :reader emacsql-types
+          :initform '((integer "INTEGER")
+                      (float "REAL")
+                      (object "TEXT")
+                      (nil nil)))
+   ;; Cannot use `process' slot because we cannot completely
+   ;; change the type of a slot, just make it more specific.
+   (handle :documentation "Database handle."
+           :accessor emacsql-process))
+  (:documentation "A connection to a SQLite database using builtin support."))
+
+(cl-defmethod initialize-instance :after
+  ((connection emacsql-sqlite-builtin-connection) &rest _)
+  (setf (emacsql-process connection)
+        (sqlite-open (slot-value connection 'file)))
+  (when emacsql-global-timeout
+    (emacsql connection [:pragma (= busy-timeout $s1)]
+             (/ (* emacsql-global-timeout 1000) 2)))
+  (emacsql-register connection))
+
+(cl-defun emacsql-sqlite-builtin (file &key debug)
+  "Open a connected to database stored in FILE.
+If FILE is nil use an in-memory database.
+
+:debug LOG -- When non-nil, log all SQLite commands to a log
+buffer. This is for debugging purposes."
+  (let ((connection (make-instance #'emacsql-sqlite-builtin-connection
+                                   :file file)))
+    (when debug
+      (emacsql-enable-debugging connection))
+    connection))
+
+(cl-defmethod emacsql-live-p ((connection emacsql-sqlite-builtin-connection))
+  (and (emacsql-process connection) t))
+
+(cl-defmethod emacsql-close ((connection emacsql-sqlite-builtin-connection))
+  (sqlite-close (emacsql-process connection))
+  (setf (emacsql-process connection) nil))
+
+(cl-defmethod emacsql-send-message
+  ((connection emacsql-sqlite-builtin-connection) message)
+  (condition-case err
+      (mapcar (lambda (row)
+                (mapcar (lambda (col)
+                          (cond ((null col) nil)
+                                ((equal col "") "")
+                                ((numberp col) col)
+                                (t (read col))))
+                        row))
+              (sqlite-select (emacsql-process connection) message nil nil))
+    ((db-error sql-error)
+     (pcase-let ((`(,sym ,msg ,code) err))
+       (signal (or (cadr (cl-assoc code emacsql-sqlite-condition-alist
+                                   :test #'memql))
+                   'emacsql-error)
+               (list msg code sym))))
+    (error
+     (signal 'emacsql-error err))))
+
+(cl-defmethod emacsql ((connection emacsql-sqlite-builtin-connection) sql &rest args)
+  (emacsql-send-message connection (apply #'emacsql-compile connection sql args)))
+
+(provide 'emacsql-sqlite-builtin)
+
+;;; emacsql-sqlite-builtin.el ends here

--- a/emacsql-sqlite-module.el
+++ b/emacsql-sqlite-module.el
@@ -1,0 +1,96 @@
+;;; emacsql-sqlite-module.el --- EmacSQL back-end for SQLite using a module  -*- lexical-binding: t; -*-
+
+;; This is free and unencumbered software released into the public domain.
+
+;; Author: Christopher Wellons <wellons@nullprogram.com>
+;; URL: https://github.com/skeeto/emacsql
+;; Version: 3.0.0-git
+;; Package-Requires: ((emacs "29") (emacsql "3.0.0") (emacsql-sqlite "3.0.0"))
+
+;;; Commentary:
+
+;; EmacSQL back-end for SQLite using a module provided by the `sqlite3'
+;; package from https://github.com/pekingduck/emacs-sqlite3-api.
+
+;;; Code:
+
+(require 'sqlite3)
+(require 'emacsql)
+;; For `emacsql-sqlite-reserved' and `emacsql-sqlite-condition-alist'.
+(require 'emacsql-sqlite)
+
+(defclass emacsql-sqlite-module-connection (emacsql-connection)
+  ((file :initarg :file
+         :type (or null string)
+         :documentation "Database file name.")
+   (types :allocation :class
+          :reader emacsql-types
+          :initform '((integer "INTEGER")
+                      (float "REAL")
+                      (object "TEXT")
+                      (nil nil)))
+   ;; Cannot use `process' slot because we cannot completely
+   ;; change the type of a slot, just make it more specific.
+   (handle :documentation "Database handle."
+           :accessor emacsql-process))
+  (:documentation "A connection to a SQLite database using a module."))
+
+(cl-defmethod initialize-instance :after
+  ((connection emacsql-sqlite-module-connection) &rest _)
+  (setf (emacsql-process connection)
+        (sqlite3-open (or (slot-value connection 'file) ":memory:")
+                      sqlite-open-readwrite
+                      sqlite-open-create))
+  (when emacsql-global-timeout
+    (emacsql connection [:pragma (= busy-timeout $s1)]
+             (/ (* emacsql-global-timeout 1000) 2)))
+  (emacsql-register connection))
+
+(cl-defun emacsql-sqlite-module (file &key debug)
+  "Open a connected to database stored in FILE.
+If FILE is nil use an in-memory database.
+
+:debug LOG -- When non-nil, log all SQLite commands to a log
+buffer. This is for debugging purposes."
+  (let ((connection (make-instance #'emacsql-sqlite-module-connection
+                                   :file file)))
+    (when debug
+      (emacsql-enable-debugging connection))
+    connection))
+
+(cl-defmethod emacsql-live-p ((connection emacsql-sqlite-module-connection))
+  (and (emacsql-process connection) t))
+
+(cl-defmethod emacsql-close ((connection emacsql-sqlite-module-connection))
+  (sqlite3-close (emacsql-process connection))
+  (setf (emacsql-process connection) nil))
+
+(cl-defmethod emacsql-send-message
+  ((connection emacsql-sqlite-module-connection) message)
+  (let (rows)
+    (condition-case err
+        (sqlite3-exec (emacsql-process connection)
+                      message
+                      (lambda (_ row _)
+                        (push (mapcar (lambda (col)
+                                        (cond ((null col) nil)
+                                              ((equal col "") "")
+                                              (t (read col))))
+                                      row)
+                              rows)))
+      ((db-error sql-error)
+       (pcase-let ((`(,sym ,msg ,code) err))
+         (signal (or (cadr (cl-assoc code emacsql-sqlite-condition-alist
+                                     :test #'memql))
+                     'emacsql-error)
+                 (list msg code sym))))
+      (error
+       (signal 'emacsql-error err)))
+    (nreverse rows)))
+
+(cl-defmethod emacsql ((connection emacsql-sqlite-module-connection) sql &rest args)
+  (emacsql-send-message connection (apply #'emacsql-compile connection sql args)))
+
+(provide 'emacsql-sqlite-module)
+
+;;; emacsql-sqlite-module.el ends here


### PR DESCRIPTION
A few months ago I wrote a backend that uses the sqlite [module](https://github.com/pekingduck/emacs-sqlite3-api) by @pekingduck. Since fixing a major bug I have been using it successfully. (I just noticed I already tried to do that four years ago but for unknown reasons abandoned that effort.)

Emacs recently added builtin support for sqlite on the `master` branch (to be releases in Emacs 29).  That implementation is based on the mentioned module (but is part of Emacs itself, no module needed).

Yesterday I refreshed my Emacsql backend that uses the module and written a new one that uses the builtin support. Given that these backends are still very young, this should not be merged immediately, but I would like to learn now whether you would like to merge something like this eventually, or if I have to maintain these libraries separately.

I am going to use backends for a while myself, one for `forge` and one with `epkg`.  Since I started doing that yesterday, nothing broke so far. ;) If any users see this, I would appreciate it if they could give these backends a try too.