### PR TITLE
Bump all packages to version 3.1.0

### DIFF
--- a/emacsql-mysql.el
+++ b/emacsql-mysql.el
@@ -4,8 +4,8 @@
 
 ;; Author: Christopher Wellons <wellons@nullprogram.com>
 ;; URL: https://github.com/skeeto/emacsql
-;; Version: 1.0.0
-;; Package-Requires: ((emacs "25.1") (emacsql "2.0.0"))
+;; Version: 3.1.0
+;; Package-Requires: ((emacs "25.1") (emacsql "3.1.0"))
 
 ;;; Commentary:
 

--- a/emacsql-psql.el
+++ b/emacsql-psql.el
@@ -4,8 +4,8 @@
 
 ;; Author: Christopher Wellons <wellons@nullprogram.com>
 ;; URL: https://github.com/skeeto/emacsql
-;; Version: 1.0.0
-;; Package-Requires: ((emacs "25.1") (emacsql "2.0.0"))
+;; Version: 3.1.0
+;; Package-Requires: ((emacs "25.1") (emacsql "3.1.0"))
 
 ;;; Commentary:
 

--- a/emacsql-sqlite.el
+++ b/emacsql-sqlite.el
@@ -4,8 +4,8 @@
 
 ;; Author: Christopher Wellons <wellons@nullprogram.com>
 ;; URL: https://github.com/skeeto/emacsql
-;; Version: 1.0.0
-;; Package-Requires: ((emacs "25.1") (emacsql "2.0.0"))
+;; Version: 3.1.0
+;; Package-Requires: ((emacs "25.1") (emacsql "3.1.0"))
 
 ;;; Commentary:
 

--- a/emacsql.el
+++ b/emacsql.el
@@ -4,7 +4,7 @@
 
 ;; Author: Christopher Wellons <wellons@nullprogram.com>
 ;; URL: https://github.com/skeeto/emacsql
-;; Version: 3.0.0
+;; Version: 3.1.0
 ;; Package-Requires: ((emacs "25.1"))
 
 ;;; Commentary:
@@ -69,7 +69,7 @@
   "The EmacSQL SQL database front-end."
   :group 'comm)
 
-(defconst emacsql-version "3.0.0")
+(defconst emacsql-version "3.1.0")
 
 (defvar emacsql-global-timeout 30
   "Maximum number of seconds to wait before bailing out on a SQL command.


### PR DESCRIPTION
(Maybe just bump to "3.0.1"?)

```
* Make all extensions depend on version 3.1.0 of "emacsql".
* Bump the "Version" header in all package libraries to 3.1.0.
* Tag this very commit with "3.1.0" so that Melpa and NonGNU Elpa
  can agree what version these packages are at.
```

This replaces #84. /cc @skangas

The extension packages `emacsql-sqlite`, `emacsql-mysql` and `emacsql-psql` have already been released on Melpa Stable and because Melpa uses the latest version tag to determine what the latest version of a package is, even if it is a "secondary"/extension package that is being maintained in the repository of a "main" package, that means that these packages have already been released as version "3.0.0".

It is possible to use different version strings for different packages that are being maintained in the same repository, but because these packages have already been released as "3.0.0", we should not go back to "1.0.1".

If you want to keep the versions separate going forward, then you would have to use a different tag for each package, such as "emacsql-sqlite-3.2.0".  This would have to be added to the respective Melpa recipe: `:version-regexp "emacsql-sqlite-\\(.*\\)".

In any case, I strongly recommend that whenever you bump the "Version" header(s), that you then also tag that commit with the (respective) version tag(s).