### PR TITLE
Fix SQL truncated when print-level or print-length are changed

### DIFF
--- a/emacsql-compiler.el
+++ b/emacsql-compiler.el
@@ -516,17 +516,19 @@ Only use within `emacsql-with-params'!"
 (defun emacsql-format (expansion &rest args)
   "Fill in the variables EXPANSION with ARGS."
   (cl-destructuring-bind (format . vars) expansion
-    (apply #'format format
-           (cl-loop for (i . kind) in vars collect
-                    (let ((thing (nth i args)))
-                      (cl-case kind
-                        (:identifier (emacsql-escape-identifier thing))
-                        (:scalar (emacsql-escape-scalar thing))
-                        (:vector (emacsql-escape-vector thing))
-                        (:raw (emacsql-escape-raw thing))
-                        (:schema (emacsql-prepare-schema thing))
-                        (otherwise
-                         (emacsql-error "Invalid var type %S" kind))))))))
+    (let ((print-level nil)
+          (print-length nil))
+      (apply #'format format
+             (cl-loop for (i . kind) in vars collect
+                      (let ((thing (nth i args)))
+                        (cl-case kind
+                          (:identifier (emacsql-escape-identifier thing))
+                          (:scalar (emacsql-escape-scalar thing))
+                          (:vector (emacsql-escape-vector thing))
+                          (:raw (emacsql-escape-raw thing))
+                          (:schema (emacsql-prepare-schema thing))
+                          (otherwise
+                           (emacsql-error "Invalid var type %S" kind)))))))))
 
 (provide 'emacsql-compiler)
 


### PR DESCRIPTION
For long values or statements (like saving entire hash tables into a field, for instance), if print-level and print-length were not reset to nil, `format` (`prin1-to-string` under the hood) would truncate the string, leading to an invalid value being sent.

```emacs-lisp
    ;; Last 5 characters of the string
    ;; (eval-last-sexp does its own truncation)
    (s-right 5 (format "%s" (make-list 100 t)))
    ;; -> " t t)" if the result is not truncated
    ;;    " ...)" if it is
```