### PR TITLE
Allow (and prefer) SQLite binary compilation with Zig

### DIFF
--- a/emacsql-sqlite.el
+++ b/emacsql-sqlite.el
@@ -50,7 +50,7 @@
                        user-emacs-directory)))
   "Path to the EmacSQL backend (this is not the sqlite3 shell).")
 
-(defvar emacsql-sqlite-c-compilers '("cc" "gcc" "clang")
+(defvar emacsql-sqlite-c-compilers '("zig" "cc" "gcc" "clang")
   "List of names to try when searching for a C compiler.
 
 Each is queried using `executable-find', so full paths are
@@ -133,6 +133,11 @@ buffer. This is for debugging purposes."
       (cl-loop while (re-search-forward "-D[A-Z0-9_=]+" nil :no-error)
                collect (match-string 0)))))
 
+(defun emacsql-sqlite-compile-arguments (cc arguments)
+  (cond
+   ((string= (file-name-base cc) "zig") (cons "cc" arguments))
+   (t arguments)))
+
 (defun emacsql-sqlite-compile (&optional o-level async)
   "Compile the SQLite back-end for EmacSQL, returning non-nil on success.
 If called with non-nil ASYNC the return value is meaningless."
@@ -160,7 +165,7 @@ If called with non-nil ASYNC the return value is meaningless."
                  (let ((inhibit-read-only t))
                    (insert (mapconcat #'identity (cons cc arguments) " ") "\n")
                    (eql 0 (apply #'call-process cc nil (if async 0 t) t
-                                 arguments)))))))))
+                                 (emacsql-sqlite-compile-arguments cc arguments))))))))))
 
 ;;; Ensure the SQLite binary is available
 


### PR DESCRIPTION
This PR adds support for [using Zig as a drop-in replacement for GCC/Clang](https://andrewkelley.me/post/zig-cc-powerful-drop-in-replacement-gcc-clang.html), and prefers it if found. The sole complication was that `emacsql-sqlite-compile` offered no way to extend the list of arguments passed to the compiler, so I created a helper function (`emacsql-sqlite-compile-arguments`).

## Rationale

I primarily use Emacs on Windows. As a software developer, I’ve already set up my environment to be able to compile large, complex C/C++ projects (e.g. LLVM, openimageio, x265), but I’m not a C/C++ developer myself. I recently had trouble compiling emacsql-sqlite’s native binary and [found a trivial solution using `zig cc`](https://shivjm.blog/compiling-emacsql-sqlite-on-windows-with-zig/). I thought I’d offer it as an option here in case anyone else finds it useful.