### PR TITLE
emacsql-sqlite-builtin: Fix declare-functions

### DIFF
--- a/emacsql-sqlite-builtin.el
+++ b/emacsql-sqlite-builtin.el
@@ -16,7 +16,6 @@
 
 (require 'emacsql-sqlite)
 
-(require 'sqlite nil t)
 (declare-function sqlite-open "sqlite.c")
 (declare-function sqlite-select "sqlite.c")
 (declare-function sqlite-close "sqlite.c")
@@ -28,7 +27,6 @@
 
 (cl-defmethod initialize-instance :after
   ((connection emacsql-sqlite-builtin-connection) &rest _)
-  (require (quote sqlite))
   (oset connection handle
         (sqlite-open (oref connection file)))
   (emacsql-sqlite-set-busy-timeout connection)

--- a/emacsql-sqlite-builtin.el
+++ b/emacsql-sqlite-builtin.el
@@ -17,9 +17,9 @@
 (require 'emacsql-sqlite)
 
 (require 'sqlite nil t)
-(declare-function sqlite-open "sqlite")
-(declare-function sqlite-select "sqlite")
-(declare-function sqlite-close "sqlite")
+(declare-function sqlite-open "sqlite.c")
+(declare-function sqlite-select "sqlite.c")
+(declare-function sqlite-close "sqlite.c")
 
 (emacsql-register-reserved emacsql-sqlite-reserved)
 


### PR DESCRIPTION
All three `sqlite-*` functions used are defined in `src/sqlite.c`, not `lisp/sqlite.el`, which defines only the macro `with-sqlite-transaction`.

---

BTW, I'm curious: what is the reasoning behind having `(require 'sqlite)` and `(require 'sqlite nil t)` in `emacsql-sqlite-builtin.el`?

I see that `emacsql-sqlite.el` checks `sqlite-available-p` before loading `emacsql-sqlite-builtin.el`.  This handles cases like Emacs 29+ without SQLite support, in which case `sqlite.el` exists but `sqlite-open` etc. are not defined, and cases on Windows where `sqlite-open` etc. were defined at compile time, but the SQLite library is not found at run time.

So at first glance the `(require (quote sqlite))` in `emacsql-sqlite-builtin.el` seems to me equivalent to signalling an error on Emacs < 29, regardless of SQLite support.  Is that the intention, or is there some other thinking behind it?

Also, `(require 'sqlite nil t)` doesn't currently do anything (since EmacSQL doesn't use `with-sqlite-transaction`).  Is the `require` there for less typing down the road, when more things are added to `sqlite.el`?  Or is there some other thinking here as well?

Thanks!